### PR TITLE
[Compatibility] Use replace instead of replaceAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-html-inject",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Split your index.html into multiple files and inject them where ever you want!",
 	"files": [
 		"dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ function injectHTML(cfg?: InjectHTMLConfig): Plugin {
 				for (const attr of attrs.matchAll(attrMatcher)) {
 					data = data.replace(`{=$${attr[1]}}`, attr[2]);
 				}
-				data = data.replaceAll(
+				data = data.replace(
 					replaceAttrMatcher,
 					cfg?.replace?.undefined ?? '$&',
 				);


### PR DESCRIPTION
- Using `.replace()` instead of `.replaceAll()` for better NodeJS compatibility
- Plugin now supports NodeJS < v15.0.0